### PR TITLE
Update main.py

### DIFF
--- a/cloud_functions/runner/main.py
+++ b/cloud_functions/runner/main.py
@@ -412,7 +412,7 @@ def _ads_generation(
         config, sheet
     )
     style_guide = _style_guide_generation(
-        config, config_sheet_name, sheet, copycat_instance
+        config, config_sheet_name, sheet
     )
   copycat_instance = _instantiate_copycat_model(config, sheet)
   if "Extra Instructions for New Ads" in sheet:


### PR DESCRIPTION
Updating the call to the _style_guide_generation method.

4 arguments were given where 3 expected.

The copycat instance get's initialized within the function so not necessary to pass as argument here.